### PR TITLE
Fix file lock watching and UI thread crash when displaying errors

### DIFF
--- a/Ra2CsfToolsGUI/MainWindow.xaml.cs
+++ b/Ra2CsfToolsGUI/MainWindow.xaml.cs
@@ -204,18 +204,18 @@ namespace Ra2CsfToolsGUI
             switch (fileext)
             {
                 case ".csf":
-                    using (var fs = File.Open(filepath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                    using (var fs = File.Open(filepath, FileMode.Open, FileAccess.Read, FileShare.Read))
                     {
                         return CsfFile.LoadFromCsfFile(fs, this.GetCsfFileOptions());
                     };
                 // break;
                 case ".ini":
-                    using (var fs = File.Open(filepath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                    using (var fs = File.Open(filepath, FileMode.Open, FileAccess.Read, FileShare.Read))
                     {
                         return CsfFileIniHelper.LoadFromIniFile(fs, this.GetCsfFileOptions());
                     }
                 case ".yaml":
-                    using (var fs = File.Open(filepath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                    using (var fs = File.Open(filepath, FileMode.Open, FileAccess.Read, FileShare.Read))
                     {
                         return CsfFileExtension.LoadFromYamlFile(fs, this.GetCsfFileOptions());
                     }
@@ -972,7 +972,7 @@ namespace Ra2CsfToolsGUI
                                     }
                                     else
                                     {
-                                        throw; // 重试结束仍失败，抛出异常
+                                        throw; // Throw an exception if all retries fail
                                     }
                                 }
                             }

--- a/Ra2CsfToolsGUI/MainWindow.xaml.cs
+++ b/Ra2CsfToolsGUI/MainWindow.xaml.cs
@@ -966,7 +966,7 @@ namespace Ra2CsfToolsGUI
                                 }
                                 catch (IOException)
                                 {
-                                    if (tryCount < maxRetries)
+                                    if (tryCount < maxRetries - 1)
                                     {
                                         tryCount++;
                                         await Task.Delay(1000);

--- a/Ra2CsfToolsGUI/MainWindow.xaml.cs
+++ b/Ra2CsfToolsGUI/MainWindow.xaml.cs
@@ -120,13 +120,10 @@ namespace Ra2CsfToolsGUI
 
         private static IniData GetIniData() => new() { Configuration = IniParserConfiguration, };
 
-        private void MessageBoxPanic(Exception ex)
+        private void MessageBoxPanic(Exception ex) => this.Dispatcher.Invoke(() =>
         {
-            this.Dispatcher.Invoke(() =>
-            {
-                _ = MessageBox.Show(this, ex.Message, $"Error - {this.ApplicationName}", MessageBoxButton.OK, MessageBoxImage.Error);
-            });
-        }
+            _ = MessageBox.Show(this, ex.Message, $"Error - {this.ApplicationName}", MessageBoxButton.OK, MessageBoxImage.Error);
+        });
 
         private static IniData ParseIni(Stream stream)
         {

--- a/Ra2CsfToolsGUI/MainWindow.xaml.cs
+++ b/Ra2CsfToolsGUI/MainWindow.xaml.cs
@@ -950,9 +950,10 @@ namespace Ra2CsfToolsGUI
                         try
                         {
                             int tryCount = 0;
+                            int maxRetries = 3;
                             bool success = false;
 
-                            while (!success && tryCount <= 3)
+                            while (!success && tryCount <= maxRetries)
                             {
                                 try
                                 {
@@ -965,14 +966,14 @@ namespace Ra2CsfToolsGUI
                                 }
                                 catch (IOException)
                                 {
-                                    if (tryCount < 3)
+                                    if (tryCount < maxRetries)
                                     {
                                         tryCount++;
                                         Thread.Sleep(1000);
                                     }
                                     else
                                     {
-                                        throw; // Throw an exception if all retries fail
+                                        throw; // Throw IOException if all retries fail
                                     }
                                 }
                             }

--- a/Ra2CsfToolsGUI/MainWindow.xaml.cs
+++ b/Ra2CsfToolsGUI/MainWindow.xaml.cs
@@ -953,7 +953,7 @@ namespace Ra2CsfToolsGUI
                             int maxRetries = 3;
                             bool success = false;
 
-                            while (!success && tryCount <= maxRetries)
+                            while (!success && tryCount < maxRetries)
                             {
                                 try
                                 {

--- a/Ra2CsfToolsGUI/MainWindow.xaml.cs
+++ b/Ra2CsfToolsGUI/MainWindow.xaml.cs
@@ -15,6 +15,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 
 namespace Ra2CsfToolsGUI
@@ -945,7 +946,7 @@ namespace Ra2CsfToolsGUI
                         NotifyFilter = NotifyFilters.LastWrite,
                     };
                     Watches.Add(fileSystemWatcher);
-                    fileSystemWatcher.Changed += (s, e) =>
+                    fileSystemWatcher.Changed += async (s, e) =>
                     {
                         try
                         {
@@ -969,7 +970,7 @@ namespace Ra2CsfToolsGUI
                                     if (tryCount < maxRetries)
                                     {
                                         tryCount++;
-                                        Thread.Sleep(1000);
+                                        await Task.Delay(1000);
                                     }
                                     else
                                     {

--- a/Ra2CsfToolsGUI/MainWindow.xaml.cs
+++ b/Ra2CsfToolsGUI/MainWindow.xaml.cs
@@ -54,6 +54,8 @@ namespace Ra2CsfToolsGUI
 
         private const string WatchModeConfigFile = "watch_mode_config.dat";
 
+        private const int WatchModeMaxRetries = 3;
+
         private bool StartedFromCsf = false;
 
         private bool _AdvancedMode = false;
@@ -951,7 +953,7 @@ namespace Ra2CsfToolsGUI
                         try
                         {
                             int tryCount = 0;
-                            int maxRetries = 3;
+                            int maxRetries = WatchModeMaxRetries;
                             bool success = false;
 
                             while (!success && tryCount < maxRetries)


### PR DESCRIPTION
Fix a problem caused by watch a file locked by other editor
Fix a crash when catch an error not in UI thread